### PR TITLE
Change error handling in worker threads

### DIFF
--- a/include/nadjieb/mjpeg_streamer.hpp
+++ b/include/nadjieb/mjpeg_streamer.hpp
@@ -63,6 +63,8 @@ class MJPEGStreamer : public nadjieb::utils::NonCopyable {
 
     bool isRunning() { return (publisher_.isRunning() && listener_.isRunning()); }
 
+    bool  allWorkersActive() { return publisher_.allWorkersActive(); }
+
     bool hasClient(const std::string& path) { return publisher_.hasClient(path); }
 
    private:

--- a/single_include/nadjieb/mjpeg_streamer.hpp
+++ b/single_include/nadjieb/mjpeg_streamer.hpp
@@ -678,6 +678,7 @@ class Publisher : public nadjieb::utils::NonCopyable, public nadjieb::utils::Run
     virtual ~Publisher() { stop(); }
 
     void start(int num_workers = std::thread::hardware_concurrency()) {
+        num_workers_ = num_workers;
         state_ = nadjieb::utils::State::BOOTING;
         end_publisher_ = false;
         workers_.reserve(num_workers);
@@ -692,6 +693,7 @@ class Publisher : public nadjieb::utils::NonCopyable, public nadjieb::utils::Run
         end_publisher_ = true;
         condition_.notify_all();
 
+        std::unique_lock<std::mutex> lock(workers_mtx_);
         if (!workers_.empty()) {
             for (auto& w : workers_) {
                 if (w.joinable()) {
@@ -753,6 +755,11 @@ class Publisher : public nadjieb::utils::NonCopyable, public nadjieb::utils::Run
 
     bool hasClient(const std::string& path) { return topics_[path].hasClient(); }
 
+    bool allWorkersActive() {
+        std::unique_lock<std::mutex> lock(workers_mtx_);
+        return workers_.size() == num_workers_;
+    }
+
    private:
     typedef std::pair<std::string, NADJIEB_MJPEG_STREAMER_POLLFD> Payload;
 
@@ -764,11 +771,14 @@ class Publisher : public nadjieb::utils::NonCopyable, public nadjieb::utils::Run
     std::mutex cv_mtx_;
     std::mutex path_by_client_mtx_;
     std::mutex payloads_mtx_;
+    std::mutex workers_mtx_;
     bool end_publisher_ = true;
+    int num_workers_ = 0;
 
     const static int LIMIT_QUEUE_PER_CLIENT = 5;
 
     void worker() {
+        int res{0};
         while (!end_publisher_) {
             std::unique_lock<std::mutex> cv_lock(cv_mtx_);
 
@@ -796,7 +806,8 @@ class Publisher : public nadjieb::utils::NonCopyable, public nadjieb::utils::Run
             auto socket_count = pollSockets(&payload.second, 1, 1);
 
             if (socket_count == NADJIEB_MJPEG_STREAMER_SOCKET_ERROR) {
-                throw std::runtime_error("pollSockets() failed\n");
+                res = -1;
+                break;
             }
 
             if (socket_count == 0) {
@@ -804,10 +815,24 @@ class Publisher : public nadjieb::utils::NonCopyable, public nadjieb::utils::Run
             }
 
             if (payload.second.revents != POLLWRNORM) {
-                throw std::runtime_error("revents != POLLWRNORM\n");
+                res = -1;
+                break;
             }
 
             sendViaSocket(payload.second.fd, res_str.c_str(), res_str.size(), 0);
+        }
+
+        if (res) { removeThread(std::this_thread::get_id()); }
+    }
+
+    void removeThread(std::thread::id id) {
+        std::unique_lock<std::mutex> lock(workers_mtx_);
+        for (auto it = workers_.begin(); it != workers_.end(); ++it) {
+            if (it->get_id() == id) {
+                it->detach();
+                workers_.erase(it);
+                break;
+            }
         }
     }
 };
@@ -845,6 +870,8 @@ class MJPEGStreamer : public nadjieb::utils::NonCopyable {
     void setShutdownTarget(const std::string& target) { shutdown_target_ = target; }
 
     bool isRunning() { return (publisher_.isRunning() && listener_.isRunning()); }
+
+    bool  allWorkersActive() { return publisher_.allWorkersActive(); }
 
     bool hasClient(const std::string& path) { return publisher_.hasClient(path); }
 


### PR DESCRIPTION
- Remove throw commands in worker threads and instead close thread and remove it from workers vector
- This way the failed thread can be detected with a simple check of the vector length and a restart of the publisher can be triggered